### PR TITLE
Specified dynet version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dynet
+dynet==2.0.3
 numpy==1.14.0
 gensim==0.13.4.1


### PR DESCRIPTION
dy.parameters() have been deprecated in [DyNet v2.1](https://github.com/clab/dynet/releases "DyNet Releases Changelog"). For now, we have to install v2.0.3 (the last release that supports the type of invocation done in the source code) to keep it running (at least until the code has been updated to suit the latest DyNet syntax.